### PR TITLE
Fix: Convert h5py Dataset to numpy array in loadh5()

### DIFF
--- a/psflearning/dataloader.py
+++ b/psflearning/dataloader.py
@@ -120,8 +120,7 @@ class dataloader:
                         k = None
                         break
             if k is None:
-                #dat = np.squeeze(np.array(f.get(gname)).astype(np.float32))
-                dat = f[gname]
+                dat = np.squeeze(np.array(f.get(gname)).astype(np.float32))
             else:
                 datalist = list(f[gname].keys())
                 try:


### PR DESCRIPTION
## Summary
- Fixed bug in `dataloader.py` where h5py Dataset was not converted to numpy array when `k is None`
- This caused arithmetic operations (ccd_offset subtraction, gain multiplication) to fail when `frame_range` is None (e.g., for bead z-stack data)
- Restored the original behavior that was commented out

## Test plan
- [x] Verified fix by running bead PSF learning which previously failed with `unsupported operand type(s) for -: 'Dataset' and 'int'`

Generated with [Claude Code](https://claude.ai/code)